### PR TITLE
Implement Spotify-styled login button

### DIFF
--- a/lib/screens/on_boarding/onboarding_screen.dart
+++ b/lib/screens/on_boarding/onboarding_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'onboarding_page.dart';
 import '../../main.dart';
+import '../../widgets/spotify_login_button.dart';
 
 class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({super.key});
@@ -12,6 +13,7 @@ class OnboardingScreen extends StatefulWidget {
 class _OnboardingScreenState extends State<OnboardingScreen> {
   final PageController _controller = PageController();
   int _currentPage = 0;
+  bool _isSpotifyLoading = false;
 
   final List<OnboardingPage> _pages = const [
     OnboardingPage(
@@ -51,6 +53,27 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       context,
       MaterialPageRoute(builder: (_) => const MainScreen()),
     );
+  }
+
+  void _handleSpotifyLogin() async {
+    setState(() {
+      _isSpotifyLoading = true;
+    });
+
+    // TODO: Implement actual Spotify OAuth flow
+    // For now, simulate loading and navigate to main screen
+    await Future.delayed(const Duration(seconds: 2));
+    
+    if (mounted) {
+      setState(() {
+        _isSpotifyLoading = false;
+      });
+
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const MainScreen()),
+      );
+    }
   }
 
   @override
@@ -110,26 +133,29 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                     ),
                   ),
 
-                  // Next button
-                  ElevatedButton(
-                    onPressed: _nextPage,
-                    style: ElevatedButton.styleFrom(
-                      shape: const StadiumBorder(),
-                      backgroundColor: Colors.deepPurple,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 24,
-                        vertical: 12,
-                      ),
-                    ),
-                    child: Text(
-                      style: TextStyle(
-                        color: Colors.white,
-                      ),
-                      _currentPage == _pages.length - 1
-                          ? "Get Started"
-                          : "Next",
-                    ),
-                  ),
+                  // Next button or Spotify login button
+                  _currentPage == _pages.length - 1
+                      ? SpotifyLoginButton(
+                          onPressed: _handleSpotifyLogin,
+                          isLoading: _isSpotifyLoading,
+                        )
+                      : ElevatedButton(
+                          onPressed: _nextPage,
+                          style: ElevatedButton.styleFrom(
+                            shape: const StadiumBorder(),
+                            backgroundColor: Colors.deepPurple,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 24,
+                              vertical: 12,
+                            ),
+                          ),
+                          child: const Text(
+                            "Next",
+                            style: TextStyle(
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
                 ],
               ),
             ),

--- a/lib/widgets/spotify_login_button.dart
+++ b/lib/widgets/spotify_login_button.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+class SpotifyLoginButton extends StatefulWidget {
+  final VoidCallback? onPressed;
+  final bool isLoading;
+  final String text;
+
+  const SpotifyLoginButton({
+    super.key,
+    this.onPressed,
+    this.isLoading = false,
+    this.text = "Continue with Spotify",
+  });
+
+  @override
+  State<SpotifyLoginButton> createState() => _SpotifyLoginButtonState();
+}
+
+class _SpotifyLoginButtonState extends State<SpotifyLoginButton> {
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: widget.isLoading ? null : widget.onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: const Color(0xFF1DB954), // Spotify green
+        foregroundColor: Colors.white,
+        shape: const StadiumBorder(),
+        padding: const EdgeInsets.symmetric(
+          horizontal: 24,
+          vertical: 12,
+        ),
+        elevation: 2,
+        shadowColor: const Color(0xFF1DB954).withOpacity(0.3),
+      ),
+      child: widget.isLoading
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+              ),
+            )
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Spotify logo icon
+                Container(
+                  width: 20,
+                  height: 20,
+                  decoration: const BoxDecoration(
+                    color: Colors.white,
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.music_note,
+                    color: Color(0xFF1DB954),
+                    size: 14,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  widget.text,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}


### PR DESCRIPTION
- Create SpotifyLoginButton widget with authentic Spotify styling
- Use Spotify green color (#1DB954) and proper branding
- Add loading state with circular progress indicator
- Integrate button into onboarding screen on last page
- Replace 'Get Started' button with Spotify login on Page 3
- Add proper async handling with mounted check
- Simulate 2-second loading for demo purposes

Features:
✅ Spotify green color (#1DB954)
✅ Spotify logo/icon (music note in white circle)
✅ Loading state with spinner
✅ Proper button styling and elevation
✅ Seamless integration with onboarding flow